### PR TITLE
TASK-0 encode the merge id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,8 +174,7 @@ task getMergeStatus(type: org._10ne.gradle.rest.RestTask) {
 	def targetURL = findProperty("targetURL")
 
 	httpMethod = 'get'
-	//uri = "${targetURL}/api/v1/merges/${" + java.net.URLEncoder.encode(mergeId, "UTF-8") + "}" 
-	uri = "${targetURL}/api/v1/merges/${mergeId}"
+	uri = "${targetURL}/api/v1/merges/${java.net.URLEncoder.encode(mergeId, "UTF-8")}"
 
 	username = project.pegaUsername
 	password = project.pegaPassword


### PR DESCRIPTION
Putting this back, it is required because the merge id has a space in it.